### PR TITLE
Notify Slack Refactor

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,8 +1,4 @@
 class StaticController < ApplicationController
-
-	require "net/http"
-	require "uri"
-	
 	def dashboard
 		@summary = Score.summary[0]
 		@products_count = Product.count

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -18,14 +18,8 @@ class StaticController < ApplicationController
 	end
 
 	def send_to_slack
-		message_to_send = "#{params[:Message]} - <mailto:#{params[:email]}|#{params[:name]}>"
-		url = URI.parse(CONFIGS[:feedback_slack]["endpoint"])
-		http = Net::HTTP.new(url.host, url.port)
-		http.use_ssl = true
-		req = Net::HTTP::Post.new(url.request_uri)
-		req.body = {"channel"=>CONFIGS[:feedback_slack]["channel_name"], "username"=>"Feedback-BOT", "text"=>message_to_send, "icon_emoji"=>":rocket:"}.to_json
-		res = http.request(req)
-
+		NotifySlackService.build.call({ name: params[:name], email: params[:email], message: params[:message] })
+		flash[:notice] = {:type => 'success', :message => 'Thanks for your valuable feedback.'}
 		redirect_to :controller => 'products', :action => 'index'
 	end
 

--- a/app/services/notify_slack_service.rb
+++ b/app/services/notify_slack_service.rb
@@ -1,0 +1,26 @@
+class NotifySlackService
+	def self.build
+		new
+	end
+
+	def call(params)
+		begin
+			message_to_send = "#{params[:message]} - <mailto:#{params[:email]}|#{params[:name]}>"
+			config = CONFIGS[:feedback_slack]
+			url = URI.parse(config['endpoint'])
+			http = Net::HTTP.new(url.host, url.port)
+			http.use_ssl = true
+			req = Net::HTTP::Post.new(url.request_uri)
+			req.body = {
+				'channel'=>config['channel_name'],
+				'username'=>'Feedback-BOT',
+				'text'=>message_to_send,
+				'icon_emoji'=>':rocket:'
+			}.to_json
+			res = http.request(req)
+			res.kind_of? Net::HTTPSuccess
+		rescue => e
+			# Log exception
+		end
+	end
+end

--- a/app/services/notify_slack_service.rb
+++ b/app/services/notify_slack_service.rb
@@ -1,4 +1,7 @@
 class NotifySlackService
+	require "net/http"
+	require "uri"
+
 	def self.build
 		new
 	end

--- a/app/views/static/contact.html.erb
+++ b/app/views/static/contact.html.erb
@@ -39,8 +39,8 @@
 			<div class="row">
 				<div class="col-md-12">
 					<div class="input-group" style="width: 100%">
-						<input id="Message" name="Message" type="text" class="input-group__text-field has-content" required>
-						<label for="Message" class="input-group__label">
+						<input id="message" name="message" type="text" class="input-group__text-field has-content" required>
+						<label for="message" class="input-group__label">
 							Message <span class="input-group__required">*</span>
 						</label>
 					</div>

--- a/config/application.yml
+++ b/config/application.yml
@@ -2,8 +2,8 @@ default: &default
   feature_flags:
     tags: false
   feedback_slack:
-    endpoint: "https://hooks.slack.com/services/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"
-    channel_name: "#Techmaturity-feedback"
+    endpoint: "#endpoint"
+    channel_name: "#channel_name"
 
 development:
   <<: *default
@@ -12,4 +12,8 @@ test:
   <<: *default
 
 production:
-  <<: *default
+  feature_flags:
+    tags: false
+  feedback_slack:
+    endpoint: "https://hooks.slack.com/services/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"
+    channel_name: "#Techmaturity-feedback"


### PR DESCRIPTION
**Changes:**
* Move the slack API integration into services layer to keep the controller thin. https://hackernoon.com/going-further-with-service-objects-in-ruby-on-rails-b8aac13a7271
* Move Slack channel URL to prod env under config/application.yml. This prevents accidental sending of slack messages from dev env.