### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,16 @@ RUN apk add --no-cache openssl ttf-dejavu && \
     echo "057ecd4ac1d3c3be31f82fc0848bf77b1326a975b4f8423fe31607205a0fe945  /usr/local/bin/dumb-init" | sha256sum -c && \
     chmod +x /usr/local/bin/dumb-init
 
+COPY Gemfile* /tmp/
+WORKDIR /tmp
+RUN bundle install
+
 RUN mkdir /techmaturity
 COPY . /techmaturity
 WORKDIR /techmaturity
 
 RUN chmod 555 entrypoint.sh
 ENV RAILS_ENV production
-RUN bundle install
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir /techmaturity
 COPY . /techmaturity
 WORKDIR /techmaturity
 
-RUN chmod 777 entrypoint.sh
+RUN chmod 555 entrypoint.sh
 ENV RAILS_ENV production
 RUN bundle install
 


### PR DESCRIPTION
I wanted to suggest an update to the Dockerfile with the following changes:

* I wasn't sure if there was a requirement to maintain 777 permissions for *entrypoint.sh*, but 555 seems like better practice and maybe keeps security auditors happy.
* I moved `bundle install` earlier in the dockerfile to improve docker image caching. This way, you'll have quicker rebuilds for code changes rather than waiting every build for gem installation. 