### PR TITLE
Move bundle install to before code copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,17 @@ RUN apk add --no-cache openssl ttf-dejavu && \
     echo "057ecd4ac1d3c3be31f82fc0848bf77b1326a975b4f8423fe31607205a0fe945  /usr/local/bin/dumb-init" | sha256sum -c && \
     chmod +x /usr/local/bin/dumb-init
 
+COPY Gemfile* /tmp/
+WORKDIR /tmp
+
+RUN bundle install
+
 RUN mkdir /techmaturity
 COPY . /techmaturity
 WORKDIR /techmaturity
 
 RUN chmod 777 entrypoint.sh
 ENV RAILS_ENV production
-RUN bundle install
 
 EXPOSE 3000
 


### PR DESCRIPTION
Get back a minute every build by moving the code copy to after the bundle install